### PR TITLE
Minor fixes and updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,4 @@ maintenance = { status = "actively-developed" }
 enet-sys = "0.2.2"
 failure = "0.1.5"
 failure_derive = "0.1.5"
-byteorder = "1.3.1"
 lazy_static = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,6 @@ maintenance = { status = "actively-developed" }
 enet-sys = "0.2.2"
 failure = "0.1.5"
 failure_derive = "0.1.5"
+
+[dev-dependencies]
 lazy_static = "1.3.0"

--- a/src/address.rs
+++ b/src/address.rs
@@ -23,7 +23,7 @@ impl Address {
 
     /// Create a new address from a given hostname.
     pub fn from_hostname(hostname: &CString, port: u16) -> Result<Address, Error> {
-        use enet_sys::{enet_address_set_host};
+        use enet_sys::enet_address_set_host;
 
         let mut addr = ENetAddress { host: 0, port };
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,8 +1,6 @@
 use std::ffi::CString;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
-use byteorder::{NetworkEndian, ReadBytesExt};
-
 use crate::Error;
 
 use enet_sys::ENetAddress;
@@ -52,10 +50,7 @@ impl Address {
 
     pub(crate) fn to_enet_address(&self) -> ENetAddress {
         ENetAddress {
-            host: (&self.ip().octets() as &[u8])
-                .read_u32::<NetworkEndian>()
-                .unwrap()
-                .to_be(),
+            host: u32::from_be_bytes(self.ip().octets()).to_be(),
             port: self.port(),
         }
     }

--- a/src/address.rs
+++ b/src/address.rs
@@ -68,6 +68,12 @@ impl Address {
     }
 }
 
+impl From<SocketAddrV4> for Address {
+    fn from(addr: SocketAddrV4) -> Address {
+        Address { addr }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Address;


### PR DESCRIPTION
These commits make the following changes:

- Replace `std::mem::uninitialized` that, when used, produces a warning from the compiler about deprecation with `std::mem::MaybeUninit` (stable since 1.36.0)
-  Remove dependency on byteorder, use functions from std for converting endianity instead, namely `u32::from_be_bytes` and `u32::to_be`
- Implement `From<SocketAddrV4>` for `Address` for convenience
- Put lazy_static into `dev-dependencies` in Cargo.toml since it's only used for tests

