### PR TITLE
Huge update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,4 @@ maintenance = { status = "actively-developed" }
 enet-sys = "0.2.2"
 failure = "0.1.5"
 failure_derive = "0.1.5"
-byteorder = "1.3.1"
 lazy_static = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,6 @@ maintenance = { status = "actively-developed" }
 enet-sys = "0.2.2"
 failure = "0.1.5"
 failure_derive = "0.1.5"
+
+[dev-dependencies]
 lazy_static = "1.3.0"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -50,7 +50,7 @@ fn main() {
 
     // send a "hello"-like packet
     peer.send_packet(
-        Packet::new(b"harro", PacketMode::ReliableSequenced).unwrap(),
+        Packet::new(b"harro".to_vec(), PacketMode::ReliableSequenced).unwrap(),
         1,
     )
     .unwrap();

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -3,6 +3,7 @@ extern crate enet;
 use std::net::Ipv4Addr;
 
 use enet::*;
+use std::time::Duration;
 
 fn main() {
     let enet = Enet::new().expect("could not initialize ENet");
@@ -21,7 +22,9 @@ fn main() {
         .expect("connect failed");
 
     let peer = loop {
-        let e = host.service(1000).expect("service failed");
+        let e = host
+            .service(Duration::from_secs(1))
+            .expect("service failed");
 
         let e = match e {
             Some(ev) => ev,
@@ -56,7 +59,7 @@ fn main() {
     peer.disconnect_later(5);
 
     loop {
-        let e = host.service(1000).unwrap();
+        let e = host.service(Duration::from_secs(1)).unwrap();
         println!("received event: {:#?}", e);
     }
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,8 +1,8 @@
 extern crate enet;
 
-use std::net::Ipv4Addr;
-
 use enet::*;
+use std::net::Ipv4Addr;
+use std::time::Duration;
 
 fn main() {
     let enet = Enet::new().expect("could not initialize ENet");
@@ -21,7 +21,7 @@ fn main() {
 
     loop {
         // Wait 500 ms for any events.
-        if let Some(Event { peer, kind }) = host
+        if let Some(Event { kind, .. }) = host
             .service(Duration::from_millis(500))
             .expect("service failed")
         {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -20,7 +20,11 @@ fn main() {
         .expect("could not create host");
 
     loop {
-        if let Some(Event { peer, kind }) = host.service(None).expect("service failed") {
+        // Wait 500 ms for any events.
+        if let Some(Event { peer, kind }) = host
+            .service(Duration::from_millis(500))
+            .expect("service failed")
+        {
             match kind {
                 EventKind::Connect => println!("new connection!"),
                 EventKind::Disconnect { .. } => println!("disconnect!"),

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -20,16 +20,16 @@ fn main() {
         .expect("could not create host");
 
     loop {
-        match host.service(1000).expect("service failed") {
-            Some(Event::Connect(_)) => println!("new connection!"),
-            Some(Event::Disconnect(..)) => println!("disconnect!"),
-            Some(Event::Receive {
-                channel_id,
-                ref packet,
-                ..
-            }) => println!("got packet on channel {}, content: '{}'", channel_id,
-                         std::str::from_utf8(packet.data()).unwrap()),
-            _ => (),
+        if let Some(Event { peer, kind }) = host.service(None).expect("service failed") {
+            match kind {
+                EventKind::Connect => println!("new connection!"),
+                EventKind::Disconnect { .. } => println!("disconnect!"),
+                EventKind::Receive { channel_id, packet } => println!(
+                    "got packet on channel {}, content: '{}'",
+                    channel_id,
+                    std::str::from_utf8(packet.data()).unwrap()
+                ),
+            }
         }
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -23,7 +23,7 @@ impl Address {
 
     /// Create a new address from a given hostname.
     pub fn from_hostname(hostname: &CString, port: u16) -> Result<Address, Error> {
-        use enet_sys::{enet_address_set_host};
+        use enet_sys::enet_address_set_host;
 
         let mut addr = ENetAddress { host: 0, port };
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,8 +1,6 @@
 use std::ffi::CString;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
-use byteorder::{NetworkEndian, ReadBytesExt};
-
 use crate::Error;
 
 use enet_sys::ENetAddress;
@@ -52,10 +50,7 @@ impl Address {
 
     pub(crate) fn to_enet_address(&self) -> ENetAddress {
         ENetAddress {
-            host: (&self.ip().octets() as &[u8])
-                .read_u32::<NetworkEndian>()
-                .unwrap()
-                .to_be(),
+            host: u32::from_be_bytes(self.ip().octets()).to_be(),
             port: self.port(),
         }
     }

--- a/src/address.rs
+++ b/src/address.rs
@@ -68,6 +68,12 @@ impl Address {
     }
 }
 
+impl From<SocketAddrV4> for Address {
+    fn from(addr: SocketAddrV4) -> Address {
+        Address { addr }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Address;

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::CStr;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
 use crate::Error;
@@ -20,7 +20,7 @@ impl Address {
     }
 
     /// Create a new address from a given hostname.
-    pub fn from_hostname(hostname: &CString, port: u16) -> Result<Address, Error> {
+    pub fn from_hostname(hostname: &CStr, port: u16) -> Result<Address, Error> {
         use enet_sys::enet_address_set_host;
 
         let mut addr = ENetAddress { host: 0, port };

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,3 +1,4 @@
+#![allow(non_upper_case_globals)]
 use enet_sys::{
     ENetEvent, _ENetEventType_ENET_EVENT_TYPE_CONNECT, _ENetEventType_ENET_EVENT_TYPE_DISCONNECT,
     _ENetEventType_ENET_EVENT_TYPE_NONE, _ENetEventType_ENET_EVENT_TYPE_RECEIVE,

--- a/src/event.rs
+++ b/src/event.rs
@@ -14,14 +14,23 @@ pub struct Event<'a, T> {
     pub kind: EventKind,
 }
 
+/// The type of an event.
 #[derive(Debug)]
 pub enum EventKind {
     /// Peer has connected.
     Connect,
     /// Peer has disconnected.
-    Disconnect { data: u32 },
+    Disconnect {
+        /// The data associated with this event. Usually a reason for disconnection.
+        data: u32,
+    },
     /// Peer has received a packet.
-    Receive { channel_id: u8, packet: Packet },
+    Receive {
+        /// ID of the channel that the packet was received on.
+        channel_id: u8,
+        /// The received packet.
+        packet: Packet,
+    },
 }
 
 impl<'a, T> Event<'a, T> {

--- a/src/event.rs
+++ b/src/event.rs
@@ -6,7 +6,7 @@ use enet_sys::{
 
 use crate::{Packet, Peer};
 
-/// This struct represents an event that can occur when servicing an `EnetHost`.
+/// This struct represents an event that can occur when servicing an `Host`.
 #[derive(Debug)]
 pub struct Event<'a, T> {
     /// The peer that this event happened on.

--- a/src/event.rs
+++ b/src/event.rs
@@ -6,15 +6,21 @@ use enet_sys::{
 
 use crate::{Packet, Peer};
 
+/// This struct represents an event that can occur when servicing an `EnetHost`.
 pub struct Event<'a, T> {
+    /// The peer that this event happened on.
     pub peer: &'a mut Peer<T>,
+    /// The type of this event.
     pub kind: EventKind,
 }
 
 #[derive(Debug)]
 pub enum EventKind {
+    /// Peer has connected.
     Connect,
+    /// Peer has disconnected.
     Disconnect { data: u32 },
+    /// Peer has received a packet.
     Receive { channel_id: u8, packet: Packet },
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -7,6 +7,7 @@ use enet_sys::{
 use crate::{Packet, Peer};
 
 /// This struct represents an event that can occur when servicing an `EnetHost`.
+#[derive(Debug)]
 pub struct Event<'a, T> {
     /// The peer that this event happened on.
     pub peer: &'a mut Peer<T>,

--- a/src/event.rs
+++ b/src/event.rs
@@ -21,6 +21,8 @@ pub enum EventKind {
     /// Peer has connected.
     Connect,
     /// Peer has disconnected.
+    //
+    /// The data of the peer will be dropped on the next call to Host::service or when the structure is dropped.
     Disconnect {
         /// The data associated with this event. Usually a reason for disconnection.
         data: u32,

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,60 +5,37 @@ use enet_sys::{
 
 use crate::{Packet, Peer};
 
-/// This enum represents an event that can occur when servicing an `EnetHost`.
-///
-/// Also see the official ENet documentation for more information.
+pub struct Event<'a, T> {
+    pub peer: &'a mut Peer<T>,
+    pub kind: EventKind,
+}
+
 #[derive(Debug)]
-pub enum Event<'a, T> {
-    /// This variant represents the connection of a peer, contained in the only field.
-    Connect(Peer<'a, T>),
-    /// This variant represents the disconnection of a peer, either because it was requested or due to a timeout.
-    ///
-    /// The disconnected peer is contained in the first field, while the second field contains the user-specified
-    /// data for this disconnection.
-    Disconnect(Peer<'a, T>, u32),
-    /// This variants repersents a packet that was received.
-    Receive {
-        /// The `Peer` that sent the packet.
-        sender: Peer<'a, T>,
-        /// The channel on which the packet was received.
-        channel_id: u8,
-        /// The `Packet` that was received.
-        packet: Packet,
-    },
+pub enum EventKind {
+    Connect,
+    Disconnect { data: u32 },
+    Receive { channel_id: u8, packet: Packet },
 }
 
 impl<'a, T> Event<'a, T> {
-    pub(crate) fn from_sys_event<'b>(event_sys: &'b ENetEvent) -> Option<Event<'a, T>> {
-        #[allow(non_upper_case_globals)]
-        match event_sys.type_ {
-            _ENetEventType_ENET_EVENT_TYPE_NONE => None,
-            _ENetEventType_ENET_EVENT_TYPE_CONNECT => {
-                Some(Event::Connect(Peer::new(event_sys.peer)))
-            }
-            _ENetEventType_ENET_EVENT_TYPE_DISCONNECT => Some(Event::Disconnect(
-                Peer::new(event_sys.peer),
-                event_sys.data,
-            )),
-            _ENetEventType_ENET_EVENT_TYPE_RECEIVE => Some(Event::Receive {
-                sender: Peer::new(event_sys.peer),
+    pub(crate) fn from_sys_event(event_sys: &ENetEvent) -> Option<Event<'a, T>> {
+        if event_sys.type_ == _ENetEventType_ENET_EVENT_TYPE_NONE {
+            return None;
+        }
+
+        let peer = Peer::new_mut(unsafe { &mut *event_sys.peer });
+        let kind = match event_sys.type_ {
+            _ENetEventType_ENET_EVENT_TYPE_CONNECT => EventKind::Connect,
+            _ENetEventType_ENET_EVENT_TYPE_DISCONNECT => EventKind::Disconnect {
+                data: event_sys.data,
+            },
+            _ENetEventType_ENET_EVENT_TYPE_RECEIVE => EventKind::Receive {
                 channel_id: event_sys.channelID,
                 packet: Packet::from_sys_packet(event_sys.packet),
-            }),
-            _ => panic!("unrecognized event type: {}", event_sys.type_),
-        }
-    }
-}
+            },
+            _ => panic!("unexpected event type: {}", event_sys.type_),
+        };
 
-impl<'a, T> Drop for Event<'a, T> {
-    fn drop(&mut self) {
-        match self {
-            // Seemingly, the lifetime of an ENetPeer ends with the end of the Disconnect event.
-            // However, this is *not really clear* in the ENet docs!
-            // It looks like the Peer *might* live longer, but not shorter, so it should be safe
-            // to destroy the associated data (if any) here.
-            Event::Disconnect(peer, _) => peer.set_data(None),
-            _ => (),
-        }
+        Some(Event { peer, kind })
     }
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::mem::MaybeUninit;
+use std::mem::{self, MaybeUninit};
 use std::ops::{Index, IndexMut};
 use std::sync::Arc;
 use std::time::Duration;
@@ -185,8 +185,10 @@ impl<T> Host<T> {
 
         let event = Event::from_sys_event(&sys_event);
         if let Some(EventKind::Disconnect { .. }) = event.as_ref().map(|event| &event.kind) {
-            self.disconnect_drop =
-                Some(unsafe { sys_event.peer as usize - (*self.inner).peers as usize });
+            self.disconnect_drop = Some(unsafe {
+                (sys_event.peer as usize - (*self.inner).peers as usize)
+                    / mem::size_of::<ENetPeer>()
+            });
         }
 
         event

--- a/src/host.rs
+++ b/src/host.rs
@@ -241,19 +241,19 @@ impl<T> Host<T> {
     /// The connection will not be done until a `Event::Connected` for this peer was received.
     ///
     /// `channel_count` specifies how many channels to allocate for this peer.
-    /// `user_data` is a user-specified value that can be chosen arbitrarily.
+    /// `data` is a user-specified value that can be chosen arbitrarily.
     pub fn connect(
         &mut self,
         address: &Address,
         channel_count: usize,
-        user_data: u32,
+        data: u32,
     ) -> Result<&mut Peer<T>, Error> {
         let res: *mut ENetPeer = unsafe {
             enet_host_connect(
                 self.inner,
                 &address.to_enet_address() as *const _,
                 channel_count,
-                user_data,
+                data,
             )
         };
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -133,7 +133,7 @@ impl<T> Host<T> {
     }
 
     /// Returns an iterator over all peers connected to this `Host`.
-    pub fn peers_mut(&'_ mut self) -> impl Iterator<Item = &'_ mut Peer<T>> {
+    pub fn peers_mut(&mut self) -> impl Iterator<Item = &'_ mut Peer<T>> {
         let peers =
             unsafe { std::slice::from_raw_parts_mut((*self.inner).peers, (*self.inner).peerCount) };
 
@@ -151,7 +151,7 @@ impl<T> Host<T> {
     /// Maintains this host and delivers an event if available.
     ///
     /// This should be called regularly for ENet to work properly with good performance.
-    pub fn service(&'_ mut self, timeout_ms: u32) -> Result<Option<Event<'_, T>>, Error> {
+    pub fn service(&mut self, timeout_ms: u32) -> Result<Option<Event<'_, T>>, Error> {
         // ENetEvent is Copy (aka has no Drop impl), so we don't have to make sure we `mem::forget` it later on
         let mut sys_event = MaybeUninit::uninit();
 
@@ -168,7 +168,7 @@ impl<T> Host<T> {
     }
 
     /// Checks for any queued events on this `Host` and dispatches one if available
-    pub fn check_events(&'_ mut self) -> Result<Option<Event<'_, T>>, Error> {
+    pub fn check_events(&mut self) -> Result<Option<Event<'_, T>>, Error> {
         // ENetEvent is Copy (aka has no Drop impl), so we don't have to make sure we `mem::forget` it later on
         let mut sys_event = MaybeUninit::uninit();
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -256,7 +256,9 @@ impl<T> Host<T> {
 impl<T> Drop for Host<T> {
     /// Call the corresponding ENet cleanup-function(s).
     fn drop(&mut self) {
-        self.drop_disconnected();
+        for peer in self.peers_mut() {
+            peer.set_data(None);
+        }
 
         unsafe {
             enet_host_destroy(self.inner);

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
+use std::ops::{Index, IndexMut};
 use std::sync::Arc;
 
 use crate::{Address, EnetKeepAlive, Error, Event, EventKind, Peer};
@@ -250,6 +251,20 @@ impl<T> Host<T> {
         }
 
         Ok(Peer::new_mut(unsafe { &mut *res }))
+    }
+}
+
+impl<T> Index<usize> for Host<T> {
+    type Output = Peer<T>;
+
+    fn index(&self, idx: usize) -> &Peer<T> {
+        self.peer(idx).expect("invalid peer index")
+    }
+}
+
+impl<T> IndexMut<usize> for Host<T> {
+    fn index_mut(&mut self, idx: usize) -> &mut Peer<T> {
+        self.peer_mut(idx).expect("invalid peer index")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use crate::address::Address;
 pub use crate::event::Event;
 pub use crate::host::{BandwidthLimit, ChannelLimit, Host};
 pub use crate::packet::{Packet, PacketMode};
-pub use crate::peer::{Peer, PeerPacket, PeerState};
+pub use crate::peer::{Peer, PeerState};
 
 pub use enet_sys::ENetVersion as EnetVersion;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ mod packet;
 mod peer;
 
 pub use crate::address::Address;
-pub use crate::event::Event;
+pub use crate::event::{Event, EventKind};
 pub use crate::host::{BandwidthLimit, ChannelLimit, Host};
 pub use crate::packet::{Packet, PacketMode};
 pub use crate::peer::{Peer, PeerState};

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -106,7 +106,7 @@ impl Drop for Packet {
 }
 
 unsafe extern "C" fn packet_free_callback(packet: *mut ENetPacket) {
-    Vec::from_raw_parts(
+    Vec::<u8>::from_raw_parts(
         (*packet).data,
         (*packet).dataLength,
         (*packet).userData as usize,

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -3,18 +3,14 @@ use std::time::Duration;
 
 use enet_sys::{
     enet_peer_disconnect, enet_peer_disconnect_later, enet_peer_disconnect_now, enet_peer_receive,
-    enet_peer_reset, enet_peer_send, ENetPeer,
-    _ENetPeerState,
-    _ENetPeerState_ENET_PEER_STATE_DISCONNECTED,
-    _ENetPeerState_ENET_PEER_STATE_CONNECTING,
+    enet_peer_reset, enet_peer_send, ENetPeer, _ENetPeerState,
     _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_CONNECT,
+    _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_DISCONNECT,
+    _ENetPeerState_ENET_PEER_STATE_CONNECTED, _ENetPeerState_ENET_PEER_STATE_CONNECTING,
     _ENetPeerState_ENET_PEER_STATE_CONNECTION_PENDING,
     _ENetPeerState_ENET_PEER_STATE_CONNECTION_SUCCEEDED,
-    _ENetPeerState_ENET_PEER_STATE_CONNECTED,
-    _ENetPeerState_ENET_PEER_STATE_DISCONNECT_LATER,
-    _ENetPeerState_ENET_PEER_STATE_DISCONNECTING,
-    _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_DISCONNECT,
-    _ENetPeerState_ENET_PEER_STATE_ZOMBIE,
+    _ENetPeerState_ENET_PEER_STATE_DISCONNECTED, _ENetPeerState_ENET_PEER_STATE_DISCONNECTING,
+    _ENetPeerState_ENET_PEER_STATE_DISCONNECT_LATER, _ENetPeerState_ENET_PEER_STATE_ZOMBIE,
 };
 
 use crate::{Address, Error, Packet};
@@ -26,24 +22,149 @@ use crate::{Address, Error, Packet};
 ///
 /// ENet allows the association of arbitrary data with each peer.
 /// The type of this associated data is chosen through `T`.
-#[derive(Clone, Debug)]
-pub struct Peer<'a, T: 'a> {
-    inner: *mut ENetPeer,
-
-    _data: PhantomData<&'a mut T>,
+#[repr(transparent)]
+pub struct Peer<T> {
+    inner: ENetPeer,
+    _data: PhantomData<T>,
 }
 
-/// A packet received directly from a `Peer`.
-///
-/// Contains the received packet as well as the channel on which it was received.
-#[derive(Debug)]
-pub struct PeerPacket<'b, 'a, T: 'a> {
-    /// The packet that was received.
-    pub packet: Packet,
-    /// The channel on which the packet was received.
-    pub channel_id: u8,
+impl<'a, T> Peer<T>
+where
+    T: 'a,
+{
+    pub(crate) fn new(inner: &'a ENetPeer) -> &'a Peer<T> {
+        unsafe { &*(inner as *const _ as *const Peer<T>) }
+    }
 
-    _priv_guard: PhantomData<&'b Peer<'a, T>>,
+    pub(crate) fn new_mut(inner: &'a mut ENetPeer) -> &'a mut Peer<T> {
+        unsafe { &mut *(inner as *mut _ as *mut Peer<T>) }
+    }
+
+    /// Returns the address of this `Peer`.
+    pub fn address(&self) -> Address {
+        Address::from_enet_address(&self.inner.address)
+    }
+
+    /// Returns the amout of channels allocated for this `Peer`.
+    pub fn channel_count(&self) -> usize {
+        self.inner.channelCount
+    }
+
+    /// Returns a reference to the data associated with this `Peer`, if set.
+    pub fn data(&self) -> Option<&T> {
+        unsafe {
+            let raw_data = self.inner.data as *const T;
+
+            if raw_data.is_null() {
+                None
+            } else {
+                Some(&(*raw_data))
+            }
+        }
+    }
+
+    /// Returns a mutable reference to the data associated with this `Peer`, if set.
+    pub fn data_mut(&mut self) -> Option<&mut T> {
+        unsafe {
+            let raw_data = self.inner.data as *mut T;
+
+            if raw_data.is_null() {
+                None
+            } else {
+                Some(&mut (*raw_data))
+            }
+        }
+    }
+
+    /// Sets or clears the data associated with this `Peer`, replacing existing data.
+    pub fn set_data(&mut self, data: Option<T>) {
+        unsafe {
+            let raw_data = self.inner.data as *mut T;
+
+            if !raw_data.is_null() {
+                // free old data
+                let _: Box<T> = Box::from_raw(raw_data);
+            }
+
+            let new_data = match data {
+                Some(data) => Box::into_raw(Box::new(data)) as *mut _,
+                None => std::ptr::null_mut(),
+            };
+
+            self.inner.data = new_data;
+        }
+    }
+
+    /// Returns the downstream bandwidth of this `Peer` in bytes/second.
+    pub fn incoming_bandwidth(&self) -> u32 {
+        self.inner.incomingBandwidth
+    }
+
+    /// Returns the upstream bandwidth of this `Peer` in bytes/second.
+    pub fn outgoing_bandwidth(&self) -> u32 {
+        self.inner.outgoingBandwidth
+    }
+
+    /// Returns the mean round trip time between sending a reliable packet and receiving its acknowledgement.
+    pub fn mean_rtt(&self) -> Duration {
+        Duration::from_millis(self.inner.roundTripTime as u64)
+    }
+
+    /// Forcefully disconnects this `Peer`.
+    ///
+    /// The foreign host represented by the peer is not notified of the disconnection and will timeout on its connection to the local host.
+    pub fn reset(&mut self) {
+        unsafe {
+            enet_peer_reset(&mut self.inner as *mut _);
+        }
+    }
+
+    /// Returns the state this `Peer` is in.
+    pub fn state(&self) -> PeerState {
+        PeerState::from_sys_state(unsafe { self.inner.state })
+    }
+
+    /// Queues a packet to be sent.
+    ///
+    /// Actual sending will happen during `Host::service`.
+    pub fn send_packet(&mut self, packet: Packet, channel_id: u8) -> Result<(), Error> {
+        let res =
+            unsafe { enet_peer_send(&mut self.inner as *mut _, channel_id, packet.into_inner()) };
+
+        match res {
+            r if r > 0 => panic!("unexpected res: {}", r),
+            0 => Ok(()),
+            r if r < 0 => Err(Error(r)),
+            _ => panic!("unreachable"),
+        }
+    }
+
+    /// Disconnects from this peer.
+    ///
+    /// A `Disconnect` event will be returned by `Host::service` once the disconnection is complete.
+    pub fn disconnect(&mut self, user_data: u32) {
+        unsafe {
+            enet_peer_disconnect(&mut self.inner as *mut _, user_data);
+        }
+    }
+
+    /// Disconnects from this peer immediately.
+    ///
+    /// No `Disconnect` event will be created. No disconnect notification for the foreign peer is guaranteed, and this `Peer` is immediately reset on return from this method.
+    pub fn disconnect_now(&mut self, user_data: u32) {
+        unsafe {
+            enet_peer_disconnect_now(&mut self.inner as *mut _, user_data);
+        }
+    }
+
+    /// Disconnects from this peer after all outgoing packets have been sent.
+    ///
+    /// A `Disconnect` event will be returned by `Host::service` once the disconnection is complete.
+    pub fn disconnect_later(&mut self, user_data: u32) {
+        unsafe {
+            enet_peer_disconnect_later(&mut self.inner as *mut _, user_data);
+        }
+    }
 }
 
 /// Describes the state a `Peer` is in.
@@ -76,162 +197,11 @@ impl PeerState {
             _ENetPeerState_ENET_PEER_STATE_CONNECTED => PeerState::Connected,
             _ENetPeerState_ENET_PEER_STATE_DISCONNECT_LATER => PeerState::DisconnectLater,
             _ENetPeerState_ENET_PEER_STATE_DISCONNECTING => PeerState::Disconnecting,
-            _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_DISCONNECT => PeerState::AcknowledgingDisconnect,
+            _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_DISCONNECT => {
+                PeerState::AcknowledgingDisconnect
+            }
             _ENetPeerState_ENET_PEER_STATE_ZOMBIE => PeerState::Zombie,
             val => panic!("unexpected peer state: {}", val),
         }
-    }
-}
-
-impl<'a, T> Peer<'a, T> {
-    pub(crate) fn new(inner: *mut ENetPeer) -> Peer<'a, T> {
-        Peer {
-            inner,
-            _data: PhantomData,
-        }
-    }
-
-    /// Returns the address of this `Peer`.
-    pub fn address(&self) -> Address {
-        Address::from_enet_address(&unsafe { (*self.inner).address })
-    }
-
-    /// Returns the amout of channels allocated for this `Peer`.
-    pub fn channel_count(&self) -> usize {
-        unsafe { (*self.inner).channelCount }
-    }
-
-    /// Returns a reference to the data associated with this `Peer`, if set.
-    pub fn data(&self) -> Option<&T> {
-        unsafe {
-            let raw_data = (*self.inner).data as *const T;
-
-            if raw_data.is_null() {
-                None
-            } else {
-                Some(&(*raw_data))
-            }
-        }
-    }
-
-    /// Returns a mutable reference to the data associated with this `Peer`, if set.
-    pub fn data_mut(&mut self) -> Option<&mut T> {
-        unsafe {
-            let raw_data = (*self.inner).data as *mut T;
-
-            if raw_data.is_null() {
-                None
-            } else {
-                Some(&mut (*raw_data))
-            }
-        }
-    }
-
-    /// Sets or clears the data associated with this `Peer`, replacing existing data.
-    pub fn set_data(&mut self, data: Option<T>) {
-        unsafe {
-            let raw_data = (*self.inner).data as *mut T;
-
-            if !raw_data.is_null() {
-                // free old data
-                let _: Box<T> = Box::from_raw(raw_data);
-            }
-
-            let new_data = match data {
-                Some(data) => Box::into_raw(Box::new(data)) as *mut _,
-                None => std::ptr::null_mut(),
-            };
-
-            (*self.inner).data = new_data;
-        }
-    }
-
-    /// Returns the downstream bandwidth of this `Peer` in bytes/second.
-    pub fn incoming_bandwidth(&self) -> u32 {
-        unsafe { (*self.inner).incomingBandwidth }
-    }
-
-    /// Returns the upstream bandwidth of this `Peer` in bytes/second.
-    pub fn outgoing_bandwidth(&self) -> u32 {
-        unsafe { (*self.inner).outgoingBandwidth }
-    }
-
-    /// Returns the mean round trip time between sending a reliable packet and receiving its acknowledgement.
-    pub fn mean_rtt(&self) -> Duration {
-        Duration::from_millis(unsafe { (*self.inner).roundTripTime } as u64)
-    }
-
-    /// Forcefully disconnects this `Peer`.
-    ///
-    /// The foreign host represented by the peer is not notified of the disconnection and will timeout on its connection to the local host.
-    pub fn reset(self) {
-        unsafe {
-            enet_peer_reset(self.inner);
-        }
-    }
-
-    /// Returns the state this `Peer` is in.
-    pub fn state(&self) -> PeerState {
-        PeerState::from_sys_state(unsafe {(*self.inner).state})
-    }
-
-    /// Queues a packet to be sent.
-    ///
-    /// Actual sending will happen during `Host::service`.
-    pub fn send_packet(&mut self, packet: Packet, channel_id: u8) -> Result<(), Error> {
-        let res = unsafe { enet_peer_send(self.inner, channel_id, packet.into_inner()) };
-
-        match res {
-            r if r > 0 => panic!("unexpected res: {}", r),
-            0 => Ok(()),
-            r if r < 0 => Err(Error(r)),
-            _ => panic!("unreachable"),
-        }
-    }
-
-    /// Disconnects from this peer.
-    ///
-    /// A `Disconnect` event will be returned by `Host::service` once the disconnection is complete.
-    pub fn disconnect(&mut self, user_data: u32) {
-        unsafe {
-            enet_peer_disconnect(self.inner, user_data);
-        }
-    }
-
-    /// Disconnects from this peer immediately.
-    ///
-    /// No `Disconnect` event will be created. No disconnect notification for the foreign peer is guaranteed, and this `Peer` is immediately reset on return from this method.
-    pub fn disconnect_now(self, user_data: u32) {
-        unsafe {
-            enet_peer_disconnect_now(self.inner, user_data);
-        }
-    }
-
-    /// Disconnects from this peer after all outgoing packets have been sent.
-    ///
-    /// A `Disconnect` event will be returned by `Host::service` once the disconnection is complete.
-    pub fn disconnect_later(&mut self, user_data: u32) {
-        unsafe {
-            enet_peer_disconnect_later(self.inner, user_data);
-        }
-    }
-
-    /// Attempts to dequeue an incoming packet from this `Peer`.
-    ///
-    /// On success, returns the packet and the channel id of the receiving channel.
-    pub fn receive<'b>(&'b mut self) -> Option<PeerPacket<'b, 'a, T>> {
-        let mut channel_id = 0u8;
-
-        let res = unsafe { enet_peer_receive(self.inner, &mut channel_id as *mut _) };
-
-        if res.is_null() {
-            return None;
-        }
-
-        Some(PeerPacket {
-            packet: Packet::from_sys_packet(res),
-            channel_id,
-            _priv_guard: PhantomData,
-        })
     }
 }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -2,9 +2,8 @@ use std::marker::PhantomData;
 use std::time::Duration;
 
 use enet_sys::{
-    enet_peer_disconnect, enet_peer_disconnect_later, enet_peer_disconnect_now, enet_peer_receive,
-    enet_peer_reset, enet_peer_send, ENetPeer, _ENetPeerState,
-    _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_CONNECT,
+    enet_peer_disconnect, enet_peer_disconnect_later, enet_peer_disconnect_now, enet_peer_reset,
+    enet_peer_send, ENetPeer, _ENetPeerState, _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_CONNECT,
     _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_DISCONNECT,
     _ENetPeerState_ENET_PEER_STATE_CONNECTED, _ENetPeerState_ENET_PEER_STATE_CONNECTING,
     _ENetPeerState_ENET_PEER_STATE_CONNECTION_PENDING,
@@ -121,7 +120,7 @@ where
 
     /// Returns the state this `Peer` is in.
     pub fn state(&self) -> PeerState {
-        PeerState::from_sys_state(unsafe { self.inner.state })
+        PeerState::from_sys_state(self.inner.state)
     }
 
     /// Queues a packet to be sent.

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -142,29 +142,29 @@ where
     /// Disconnects from this peer.
     ///
     /// A `Disconnect` event will be returned by `Host::service` once the disconnection is complete.
-    pub fn disconnect(&mut self, user_data: u32) {
+    pub fn disconnect(&mut self, data: u32) {
         unsafe {
-            enet_peer_disconnect(&mut self.inner as *mut _, user_data);
+            enet_peer_disconnect(&mut self.inner as *mut _, data);
         }
     }
 
     /// Disconnects from this peer immediately.
     ///
     /// No `Disconnect` event will be created. No disconnect notification for the foreign peer is guaranteed, and this `Peer` is immediately reset on return from this method.
-    pub fn disconnect_now(&mut self, user_data: u32) {
+    pub fn disconnect_now(&mut self, data: u32) {
         self.set_data(None);
 
         unsafe {
-            enet_peer_disconnect_now(&mut self.inner as *mut _, user_data);
+            enet_peer_disconnect_now(&mut self.inner as *mut _, data);
         }
     }
 
     /// Disconnects from this peer after all outgoing packets have been sent.
     ///
     /// A `Disconnect` event will be returned by `Host::service` once the disconnection is complete.
-    pub fn disconnect_later(&mut self, user_data: u32) {
+    pub fn disconnect_later(&mut self, data: u32) {
         unsafe {
-            enet_peer_disconnect_later(&mut self.inner as *mut _, user_data);
+            enet_peer_disconnect_later(&mut self.inner as *mut _, data);
         }
     }
 }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
 use std::time::Duration;
 
@@ -163,6 +164,15 @@ where
         unsafe {
             enet_peer_disconnect_later(&mut self.inner as *mut _, user_data);
         }
+    }
+}
+
+impl<T> Debug for Peer<T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("Peer").field("data", &self.data()).finish()
     }
 }
 

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -152,6 +152,8 @@ where
     ///
     /// No `Disconnect` event will be created. No disconnect notification for the foreign peer is guaranteed, and this `Peer` is immediately reset on return from this method.
     pub fn disconnect_now(&mut self, user_data: u32) {
+        self.set_data(None);
+
         unsafe {
             enet_peer_disconnect_now(&mut self.inner as *mut _, user_data);
         }


### PR DESCRIPTION
This is a huge, backwards incompatible update aimed at improving ergonomics of the library and performance. 

The following changes have been made:
- Peers are now borrowed directly from the host and are always behind references. This is implemented in a manner similar to how `std::path::Path` is implemented in the standard library. This is done in order to be able to implement `std::ops::{Index, IndexMut}` for the `Host` structure to allow access to the peers. The peers still can not be stored anywhere, but their indexes can, so that should improve usability. As long as `Peer` does not implement `Copy` or `Clone`, this is safe. We also intentionally don't expose the peers as a mutable slice because it would be possible to change the order of elements.
- `Packet::new` now takes a `Vec<u8>` to reduce copying and allocation. This could have a huge performance impact on some applications. The `userData` field of `ENetPacket` is abused to store the capacity of the vector so that it's possible to free it from the `freeCallback` function once the packet is freed by ENet.
- `Event` has been refactored as a struct and `EventKind` has been added.
- Peer data is now dropped on disconnect, peer reset and host drop (fixes #2)
- `Address::from_hostname` takes a `std::ffi::CStr` rather than the owned counterpart
- `Host::service` takes a `std::time::Duration` as the `timeout` parameter for consistency with the rest of the Rust ecosystem
- Docs and examples are updated accordingly, the code compiles without warnings

I hope this isn't too much. Please review these changes and let me know. :)