### PR TITLE
Huge Update #2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,4 @@ maintenance = { status = "actively-developed" }
 enet-sys = "0.2.2"
 failure = "0.1.5"
 failure_derive = "0.1.5"
-byteorder = "1.3.1"
 lazy_static = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,6 @@ maintenance = { status = "actively-developed" }
 enet-sys = "0.2.2"
 failure = "0.1.5"
 failure_derive = "0.1.5"
+
+[dev-dependencies]
 lazy_static = "1.3.0"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -49,16 +49,16 @@ fn main() -> anyhow::Result<()> {
         };
     };
 
+    let peer = host.peer_mut(peer_id).unwrap();
     // send a "hello"-like packet
-    host[peer_id]
-        .send_packet(
-            Packet::new(b"harro".to_vec(), PacketMode::ReliableSequenced).unwrap(),
-            1,
-        )
-        .context("sending packet failed")?;
+    peer.send_packet(
+        Packet::new(b"harro".to_vec(), PacketMode::ReliableSequenced).unwrap(),
+        1,
+    )
+    .context("sending packet failed")?;
 
     // disconnect after all outgoing packets have been sent.
-    host[peer_id].disconnect_later(5);
+    peer.disconnect_later(5);
 
     loop {
         let e = host

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -34,12 +34,13 @@ fn main() -> anyhow::Result<()> {
 
         println!("[client] event: {:#?}", e);
 
-        match e.kind {
-            EventKind::Connect => break e.peer_id,
+        match e.kind() {
+            EventKind::Connect => break e.peer_id(),
             EventKind::Disconnect { data } => {
                 println!(
                     "connection NOT successful, peer: {:?}, reason: {}",
-                    e.peer_id, data
+                    e.peer_id(),
+                    data
                 );
                 std::process::exit(0);
             }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -51,7 +51,7 @@ fn main() {
     // send a "hello"-like packet
     host[peer_id]
         .send_packet(
-            Packet::from_vec(b"harro".to_vec(), PacketMode::ReliableSequenced).unwrap(),
+            Packet::new(b"harro".to_vec(), PacketMode::ReliableSequenced).unwrap(),
             1,
         )
         .unwrap();

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -50,7 +50,7 @@ fn main() {
 
     // send a "hello"-like packet
     peer.send_packet(
-        Packet::new(b"harro", PacketMode::ReliableSequenced).unwrap(),
+        Packet::new(b"harro".to_vec(), PacketMode::ReliableSequenced).unwrap(),
         1,
     )
     .unwrap();

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -3,6 +3,7 @@ extern crate enet;
 use std::net::Ipv4Addr;
 
 use enet::*;
+use std::time::Duration;
 
 fn main() {
     let enet = Enet::new().expect("could not initialize ENet");
@@ -21,7 +22,9 @@ fn main() {
         .expect("connect failed");
 
     let peer = loop {
-        let e = host.service(1000).expect("service failed");
+        let e = host
+            .service(Duration::from_secs(1))
+            .expect("service failed");
 
         let e = match e {
             Some(ev) => ev,
@@ -56,7 +59,7 @@ fn main() {
     peer.disconnect_later(5);
 
     loop {
-        let e = host.service(1000).unwrap();
+        let e = host.service(Duration::from_secs(1)).unwrap();
         println!("received event: {:#?}", e);
     }
 }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -50,7 +50,7 @@ fn main() {
 
     // send a "hello"-like packet
     peer.send_packet(
-        Packet::new(b"harro".to_vec(), PacketMode::ReliableSequenced).unwrap(),
+        Packet::from_vec(b"harro".to_vec(), PacketMode::ReliableSequenced).unwrap(),
         1,
     )
     .unwrap();

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,8 +1,8 @@
 extern crate enet;
 
-use std::net::Ipv4Addr;
-
 use enet::*;
+use std::net::Ipv4Addr;
+use std::time::Duration;
 
 fn main() {
     let enet = Enet::new().expect("could not initialize ENet");
@@ -21,7 +21,7 @@ fn main() {
 
     loop {
         // Wait 500 ms for any events.
-        if let Some(Event { peer, kind }) = host
+        if let Some(Event { kind, .. }) = host
             .service(Duration::from_millis(500))
             .expect("service failed")
         {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -20,7 +20,11 @@ fn main() {
         .expect("could not create host");
 
     loop {
-        if let Some(Event { peer, kind }) = host.service(None).expect("service failed") {
+        // Wait 500 ms for any events.
+        if let Some(Event { peer, kind }) = host
+            .service(Duration::from_millis(500))
+            .expect("service failed")
+        {
             match kind {
                 EventKind::Connect => println!("new connection!"),
                 EventKind::Disconnect { .. } => println!("disconnect!"),

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -22,14 +22,17 @@ fn main() -> anyhow::Result<()> {
 
     loop {
         // Wait 500 ms for any events.
-        if let Some(Event { kind, .. }) = host
+        if let Some(event) = host
             .service(Duration::from_secs(1))
             .context("service failed")?
         {
-            match kind {
-                EventKind::Connect => println!("new connection!"),
-                EventKind::Disconnect { .. } => println!("disconnect!"),
-                EventKind::Receive { channel_id, packet } => println!(
+            match event.kind() {
+                &EventKind::Connect => println!("new connection!"),
+                &EventKind::Disconnect { .. } => println!("disconnect!"),
+                &EventKind::Receive {
+                    ref channel_id,
+                    ref packet,
+                } => println!(
                     "got packet on channel {}, content: '{}'",
                     channel_id,
                     std::str::from_utf8(packet.data()).unwrap()

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -21,7 +21,7 @@ fn main() -> anyhow::Result<()> {
         .context("could not create host")?;
 
     loop {
-        // Wait 500 ms for any events.
+        // Wait 1 second for any events.
         if let Some(event) = host
             .service(Duration::from_secs(1))
             .context("service failed")?

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -20,16 +20,16 @@ fn main() {
         .expect("could not create host");
 
     loop {
-        match host.service(1000).expect("service failed") {
-            Some(Event::Connect(_)) => println!("new connection!"),
-            Some(Event::Disconnect(..)) => println!("disconnect!"),
-            Some(Event::Receive {
-                channel_id,
-                ref packet,
-                ..
-            }) => println!("got packet on channel {}, content: '{}'", channel_id,
-                         std::str::from_utf8(packet.data()).unwrap()),
-            _ => (),
+        if let Some(Event { peer, kind }) = host.service(None).expect("service failed") {
+            match kind {
+                EventKind::Connect => println!("new connection!"),
+                EventKind::Disconnect { .. } => println!("disconnect!"),
+                EventKind::Receive { channel_id, packet } => println!(
+                    "got packet on channel {}, content: '{}'",
+                    channel_id,
+                    std::str::from_utf8(packet.data()).unwrap()
+                ),
+            }
         }
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -23,7 +23,7 @@ impl Address {
 
     /// Create a new address from a given hostname.
     pub fn from_hostname(hostname: &CString, port: u16) -> Result<Address, Error> {
-        use enet_sys::{enet_address_set_host};
+        use enet_sys::enet_address_set_host;
 
         let mut addr = ENetAddress { host: 0, port };
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,8 +1,6 @@
 use std::ffi::CString;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
-use byteorder::{NetworkEndian, ReadBytesExt};
-
 use crate::Error;
 
 use enet_sys::ENetAddress;
@@ -52,10 +50,7 @@ impl Address {
 
     pub(crate) fn to_enet_address(&self) -> ENetAddress {
         ENetAddress {
-            host: (&self.ip().octets() as &[u8])
-                .read_u32::<NetworkEndian>()
-                .unwrap()
-                .to_be(),
+            host: u32::from_be_bytes(self.ip().octets()).to_be(),
             port: self.port(),
         }
     }

--- a/src/address.rs
+++ b/src/address.rs
@@ -68,6 +68,12 @@ impl Address {
     }
 }
 
+impl From<SocketAddrV4> for Address {
+    fn from(addr: SocketAddrV4) -> Address {
+        Address { addr }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Address;

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::CStr;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
 use crate::Error;
@@ -20,7 +20,7 @@ impl Address {
     }
 
     /// Create a new address from a given hostname.
-    pub fn from_hostname(hostname: &CString, port: u16) -> Result<Address, Error> {
+    pub fn from_hostname(hostname: &CStr, port: u16) -> Result<Address, Error> {
         use enet_sys::enet_address_set_host;
 
         let mut addr = ENetAddress { host: 0, port };

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,3 +1,4 @@
+#![allow(non_upper_case_globals)]
 use enet_sys::{
     ENetEvent, _ENetEventType_ENET_EVENT_TYPE_CONNECT, _ENetEventType_ENET_EVENT_TYPE_DISCONNECT,
     _ENetEventType_ENET_EVENT_TYPE_NONE, _ENetEventType_ENET_EVENT_TYPE_RECEIVE,

--- a/src/event.rs
+++ b/src/event.rs
@@ -14,14 +14,23 @@ pub struct Event<'a, T> {
     pub kind: EventKind,
 }
 
+/// The type of an event.
 #[derive(Debug)]
 pub enum EventKind {
     /// Peer has connected.
     Connect,
     /// Peer has disconnected.
-    Disconnect { data: u32 },
+    Disconnect {
+        /// The data associated with this event. Usually a reason for disconnection.
+        data: u32,
+    },
     /// Peer has received a packet.
-    Receive { channel_id: u8, packet: Packet },
+    Receive {
+        /// ID of the channel that the packet was received on.
+        channel_id: u8,
+        /// The received packet.
+        packet: Packet,
+    },
 }
 
 impl<'a, T> Event<'a, T> {

--- a/src/event.rs
+++ b/src/event.rs
@@ -6,7 +6,7 @@ use enet_sys::{
 
 use crate::{Packet, Peer};
 
-/// This struct represents an event that can occur when servicing an `EnetHost`.
+/// This struct represents an event that can occur when servicing an `Host`.
 #[derive(Debug)]
 pub struct Event<'a, T> {
     /// The peer that this event happened on.

--- a/src/event.rs
+++ b/src/event.rs
@@ -6,15 +6,21 @@ use enet_sys::{
 
 use crate::{Packet, Peer};
 
+/// This struct represents an event that can occur when servicing an `EnetHost`.
 pub struct Event<'a, T> {
+    /// The peer that this event happened on.
     pub peer: &'a mut Peer<T>,
+    /// The type of this event.
     pub kind: EventKind,
 }
 
 #[derive(Debug)]
 pub enum EventKind {
+    /// Peer has connected.
     Connect,
+    /// Peer has disconnected.
     Disconnect { data: u32 },
+    /// Peer has received a packet.
     Receive { channel_id: u8, packet: Packet },
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -7,6 +7,7 @@ use enet_sys::{
 use crate::{Packet, Peer};
 
 /// This struct represents an event that can occur when servicing an `EnetHost`.
+#[derive(Debug)]
 pub struct Event<'a, T> {
     /// The peer that this event happened on.
     pub peer: &'a mut Peer<T>,

--- a/src/event.rs
+++ b/src/event.rs
@@ -21,6 +21,8 @@ pub enum EventKind {
     /// Peer has connected.
     Connect,
     /// Peer has disconnected.
+    //
+    /// The data of the peer will be dropped on the next call to Host::service or when the structure is dropped.
     Disconnect {
         /// The data associated with this event. Usually a reason for disconnection.
         data: u32,

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,60 +5,37 @@ use enet_sys::{
 
 use crate::{Packet, Peer};
 
-/// This enum represents an event that can occur when servicing an `EnetHost`.
-///
-/// Also see the official ENet documentation for more information.
+pub struct Event<'a, T> {
+    pub peer: &'a mut Peer<T>,
+    pub kind: EventKind,
+}
+
 #[derive(Debug)]
-pub enum Event<'a, T> {
-    /// This variant represents the connection of a peer, contained in the only field.
-    Connect(Peer<'a, T>),
-    /// This variant represents the disconnection of a peer, either because it was requested or due to a timeout.
-    ///
-    /// The disconnected peer is contained in the first field, while the second field contains the user-specified
-    /// data for this disconnection.
-    Disconnect(Peer<'a, T>, u32),
-    /// This variants repersents a packet that was received.
-    Receive {
-        /// The `Peer` that sent the packet.
-        sender: Peer<'a, T>,
-        /// The channel on which the packet was received.
-        channel_id: u8,
-        /// The `Packet` that was received.
-        packet: Packet,
-    },
+pub enum EventKind {
+    Connect,
+    Disconnect { data: u32 },
+    Receive { channel_id: u8, packet: Packet },
 }
 
 impl<'a, T> Event<'a, T> {
-    pub(crate) fn from_sys_event<'b>(event_sys: &'b ENetEvent) -> Option<Event<'a, T>> {
-        #[allow(non_upper_case_globals)]
-        match event_sys.type_ {
-            _ENetEventType_ENET_EVENT_TYPE_NONE => None,
-            _ENetEventType_ENET_EVENT_TYPE_CONNECT => {
-                Some(Event::Connect(Peer::new(event_sys.peer)))
-            }
-            _ENetEventType_ENET_EVENT_TYPE_DISCONNECT => Some(Event::Disconnect(
-                Peer::new(event_sys.peer),
-                event_sys.data,
-            )),
-            _ENetEventType_ENET_EVENT_TYPE_RECEIVE => Some(Event::Receive {
-                sender: Peer::new(event_sys.peer),
+    pub(crate) fn from_sys_event(event_sys: &ENetEvent) -> Option<Event<'a, T>> {
+        if event_sys.type_ == _ENetEventType_ENET_EVENT_TYPE_NONE {
+            return None;
+        }
+
+        let peer = Peer::new_mut(unsafe { &mut *event_sys.peer });
+        let kind = match event_sys.type_ {
+            _ENetEventType_ENET_EVENT_TYPE_CONNECT => EventKind::Connect,
+            _ENetEventType_ENET_EVENT_TYPE_DISCONNECT => EventKind::Disconnect {
+                data: event_sys.data,
+            },
+            _ENetEventType_ENET_EVENT_TYPE_RECEIVE => EventKind::Receive {
                 channel_id: event_sys.channelID,
                 packet: Packet::from_sys_packet(event_sys.packet),
-            }),
-            _ => panic!("unrecognized event type: {}", event_sys.type_),
-        }
-    }
-}
+            },
+            _ => panic!("unexpected event type: {}", event_sys.type_),
+        };
 
-impl<'a, T> Drop for Event<'a, T> {
-    fn drop(&mut self) {
-        match self {
-            // Seemingly, the lifetime of an ENetPeer ends with the end of the Disconnect event.
-            // However, this is *not really clear* in the ENet docs!
-            // It looks like the Peer *might* live longer, but not shorter, so it should be safe
-            // to destroy the associated data (if any) here.
-            Event::Disconnect(peer, _) => peer.set_data(None),
-            _ => (),
-        }
+        Some(Event { peer, kind })
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -37,7 +37,7 @@ pub enum EventKind {
 }
 
 impl Event {
-    pub(crate) fn from_sys_event<T>(event_sys: &ENetEvent, host: &Host<T>) -> Option<Event> {
+    pub(crate) fn from_sys_event<T>(event_sys: ENetEvent, host: &Host<T>) -> Option<Event> {
         if event_sys.type_ == _ENetEventType_ENET_EVENT_TYPE_NONE {
             return None;
         }

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::mem::MaybeUninit;
+use std::mem::{self, MaybeUninit};
 use std::ops::{Index, IndexMut};
 use std::sync::Arc;
 use std::time::Duration;
@@ -185,8 +185,10 @@ impl<T> Host<T> {
 
         let event = Event::from_sys_event(&sys_event);
         if let Some(EventKind::Disconnect { .. }) = event.as_ref().map(|event| &event.kind) {
-            self.disconnect_drop =
-                Some(unsafe { sys_event.peer as usize - (*self.inner).peers as usize });
+            self.disconnect_drop = Some(unsafe {
+                (sys_event.peer as usize - (*self.inner).peers as usize)
+                    / mem::size_of::<ENetPeer>()
+            });
         }
 
         event

--- a/src/host.rs
+++ b/src/host.rs
@@ -241,19 +241,19 @@ impl<T> Host<T> {
     /// The connection will not be done until a `Event::Connected` for this peer was received.
     ///
     /// `channel_count` specifies how many channels to allocate for this peer.
-    /// `user_data` is a user-specified value that can be chosen arbitrarily.
+    /// `data` is a user-specified value that can be chosen arbitrarily.
     pub fn connect(
         &mut self,
         address: &Address,
         channel_count: usize,
-        user_data: u32,
+        data: u32,
     ) -> Result<&mut Peer<T>, Error> {
         let res: *mut ENetPeer = unsafe {
             enet_host_connect(
                 self.inner,
                 &address.to_enet_address() as *const _,
                 channel_count,
-                user_data,
+                data,
             )
         };
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -133,7 +133,7 @@ impl<T> Host<T> {
     }
 
     /// Returns an iterator over all peers connected to this `Host`.
-    pub fn peers_mut(&'_ mut self) -> impl Iterator<Item = &'_ mut Peer<T>> {
+    pub fn peers_mut(&mut self) -> impl Iterator<Item = &'_ mut Peer<T>> {
         let peers =
             unsafe { std::slice::from_raw_parts_mut((*self.inner).peers, (*self.inner).peerCount) };
 
@@ -151,7 +151,7 @@ impl<T> Host<T> {
     /// Maintains this host and delivers an event if available.
     ///
     /// This should be called regularly for ENet to work properly with good performance.
-    pub fn service(&'_ mut self, timeout_ms: u32) -> Result<Option<Event<'_, T>>, Error> {
+    pub fn service(&mut self, timeout_ms: u32) -> Result<Option<Event<'_, T>>, Error> {
         // ENetEvent is Copy (aka has no Drop impl), so we don't have to make sure we `mem::forget` it later on
         let mut sys_event = MaybeUninit::uninit();
 
@@ -168,7 +168,7 @@ impl<T> Host<T> {
     }
 
     /// Checks for any queued events on this `Host` and dispatches one if available
-    pub fn check_events(&'_ mut self) -> Result<Option<Event<'_, T>>, Error> {
+    pub fn check_events(&mut self) -> Result<Option<Event<'_, T>>, Error> {
         // ENetEvent is Copy (aka has no Drop impl), so we don't have to make sure we `mem::forget` it later on
         let mut sys_event = MaybeUninit::uninit();
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::mem::{self, MaybeUninit};
+use std::mem::MaybeUninit;
 use std::ops::{Index, IndexMut};
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/host.rs
+++ b/src/host.rs
@@ -256,7 +256,9 @@ impl<T> Host<T> {
 impl<T> Drop for Host<T> {
     /// Call the corresponding ENet cleanup-function(s).
     fn drop(&mut self) {
-        self.drop_disconnected();
+        for peer in self.peers_mut() {
+            peer.set_data(None);
+        }
 
         unsafe {
             enet_host_destroy(self.inner);

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,10 +1,4 @@
-use std::{
-    marker::PhantomData,
-    mem::MaybeUninit,
-    ops::{Index, IndexMut},
-    sync::Arc,
-    time::Duration,
-};
+use std::{marker::PhantomData, mem::MaybeUninit, sync::Arc, time::Duration};
 
 use enet_sys::{
     enet_host_bandwidth_limit, enet_host_channel_limit, enet_host_check_events, enet_host_connect,
@@ -178,7 +172,7 @@ impl<T> Host<T> {
             )
         };
 
-        peers.into_iter().map(|peer| Peer::new_mut(&mut *peer))
+        peers.iter_mut().map(|peer| Peer::new_mut(&mut *peer))
     }
 
     /// Returns an iterator over all peers connected to this `Host`.
@@ -190,7 +184,7 @@ impl<T> Host<T> {
             )
         };
 
-        peers.into_iter().map(|peer| Peer::new(&*peer))
+        peers.iter().map(|peer| Peer::new(&*peer))
     }
 
     fn drop_disconnected(&mut self) {
@@ -297,20 +291,6 @@ impl<T> Host<T> {
             // list of peers, which is it's PeerID.
             unsafe { self.peer_id(res) },
         ))
-    }
-}
-
-impl<T> Index<PeerID> for Host<T> {
-    type Output = Peer<T>;
-
-    fn index(&self, idx: PeerID) -> &Peer<T> {
-        self.peer(idx).expect("invalid peer index")
-    }
-}
-
-impl<T> IndexMut<PeerID> for Host<T> {
-    fn index_mut(&mut self, idx: PeerID) -> &mut Peer<T> {
-        self.peer_mut(idx).expect("invalid peer index")
     }
 }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -179,7 +179,8 @@ impl<T> Host<T> {
 
     fn drop_disconnected(&mut self) {
         if let Some(idx) = self.disconnect_drop.take() {
-            Peer::<T>::new_mut(unsafe { &mut *((*self.inner).peers.offset(idx.0 as isize)) })
+            self.peer_mut(idx)
+                .expect("Invalid PeerID in disconnect_drop in enet::Host")
                 .set_data(None);
         }
     }

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
+use std::ops::{Index, IndexMut};
 use std::sync::Arc;
 
 use crate::{Address, EnetKeepAlive, Error, Event, EventKind, Peer};
@@ -250,6 +251,20 @@ impl<T> Host<T> {
         }
 
         Ok(Peer::new_mut(unsafe { &mut *res }))
+    }
+}
+
+impl<T> Index<usize> for Host<T> {
+    type Output = Peer<T>;
+
+    fn index(&self, idx: usize) -> &Peer<T> {
+        self.peer(idx).expect("invalid peer index")
+    }
+}
+
+impl<T> IndexMut<usize> for Host<T> {
+    fn index_mut(&mut self, idx: usize) -> &mut Peer<T> {
+        self.peer_mut(idx).expect("invalid peer index")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use crate::address::Address;
 pub use crate::event::{Event, EventKind};
 pub use crate::host::{BandwidthLimit, ChannelLimit, Host};
 pub use crate::packet::{Packet, PacketMode};
-pub use crate::peer::{Peer, PeerState};
+pub use crate::peer::{Peer, PeerID, PeerState};
 
 pub use enet_sys::ENetVersion as EnetVersion;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use crate::address::Address;
 pub use crate::event::Event;
 pub use crate::host::{BandwidthLimit, ChannelLimit, Host};
 pub use crate::packet::{Packet, PacketMode};
-pub use crate::peer::{Peer, PeerPacket, PeerState};
+pub use crate::peer::{Peer, PeerState};
 
 pub use enet_sys::ENetVersion as EnetVersion;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ mod packet;
 mod peer;
 
 pub use crate::address::Address;
-pub use crate::event::Event;
+pub use crate::event::{Event, EventKind};
 pub use crate::host::{BandwidthLimit, ChannelLimit, Host};
 pub use crate::packet::{Packet, PacketMode};
 pub use crate::peer::{Peer, PeerState};

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -106,7 +106,7 @@ impl Drop for Packet {
 }
 
 unsafe extern "C" fn packet_free_callback(packet: *mut ENetPacket) {
-    Vec::from_raw_parts(
+    Vec::<u8>::from_raw_parts(
         (*packet).data,
         (*packet).dataLength,
         (*packet).userData as usize,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -64,7 +64,13 @@ impl Packet {
         let res = unsafe {
             enet_packet_create(
                 data.as_ptr() as *const _,
-                data.len() as enet_sys::size_t,
+                // This conversion should basically never fail.
+                // It may only fail if size_t and usize are of
+                // different size and the data.len() is very large,
+                // which is only possible on niche platforms.
+                data.len()
+                    .try_into()
+                    .expect("packet data too long for ENet (`size_t`)"),
                 mode.to_sys_flags() | _ENetPacketFlag_ENET_PACKET_FLAG_NO_ALLOCATE,
             )
         };

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -3,18 +3,14 @@ use std::time::Duration;
 
 use enet_sys::{
     enet_peer_disconnect, enet_peer_disconnect_later, enet_peer_disconnect_now, enet_peer_receive,
-    enet_peer_reset, enet_peer_send, ENetPeer,
-    _ENetPeerState,
-    _ENetPeerState_ENET_PEER_STATE_DISCONNECTED,
-    _ENetPeerState_ENET_PEER_STATE_CONNECTING,
+    enet_peer_reset, enet_peer_send, ENetPeer, _ENetPeerState,
     _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_CONNECT,
+    _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_DISCONNECT,
+    _ENetPeerState_ENET_PEER_STATE_CONNECTED, _ENetPeerState_ENET_PEER_STATE_CONNECTING,
     _ENetPeerState_ENET_PEER_STATE_CONNECTION_PENDING,
     _ENetPeerState_ENET_PEER_STATE_CONNECTION_SUCCEEDED,
-    _ENetPeerState_ENET_PEER_STATE_CONNECTED,
-    _ENetPeerState_ENET_PEER_STATE_DISCONNECT_LATER,
-    _ENetPeerState_ENET_PEER_STATE_DISCONNECTING,
-    _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_DISCONNECT,
-    _ENetPeerState_ENET_PEER_STATE_ZOMBIE,
+    _ENetPeerState_ENET_PEER_STATE_DISCONNECTED, _ENetPeerState_ENET_PEER_STATE_DISCONNECTING,
+    _ENetPeerState_ENET_PEER_STATE_DISCONNECT_LATER, _ENetPeerState_ENET_PEER_STATE_ZOMBIE,
 };
 
 use crate::{Address, Error, Packet};
@@ -26,24 +22,149 @@ use crate::{Address, Error, Packet};
 ///
 /// ENet allows the association of arbitrary data with each peer.
 /// The type of this associated data is chosen through `T`.
-#[derive(Clone, Debug)]
-pub struct Peer<'a, T: 'a> {
-    inner: *mut ENetPeer,
-
-    _data: PhantomData<&'a mut T>,
+#[repr(transparent)]
+pub struct Peer<T> {
+    inner: ENetPeer,
+    _data: PhantomData<T>,
 }
 
-/// A packet received directly from a `Peer`.
-///
-/// Contains the received packet as well as the channel on which it was received.
-#[derive(Debug)]
-pub struct PeerPacket<'b, 'a, T: 'a> {
-    /// The packet that was received.
-    pub packet: Packet,
-    /// The channel on which the packet was received.
-    pub channel_id: u8,
+impl<'a, T> Peer<T>
+where
+    T: 'a,
+{
+    pub(crate) fn new(inner: &'a ENetPeer) -> &'a Peer<T> {
+        unsafe { &*(inner as *const _ as *const Peer<T>) }
+    }
 
-    _priv_guard: PhantomData<&'b Peer<'a, T>>,
+    pub(crate) fn new_mut(inner: &'a mut ENetPeer) -> &'a mut Peer<T> {
+        unsafe { &mut *(inner as *mut _ as *mut Peer<T>) }
+    }
+
+    /// Returns the address of this `Peer`.
+    pub fn address(&self) -> Address {
+        Address::from_enet_address(&self.inner.address)
+    }
+
+    /// Returns the amout of channels allocated for this `Peer`.
+    pub fn channel_count(&self) -> usize {
+        self.inner.channelCount
+    }
+
+    /// Returns a reference to the data associated with this `Peer`, if set.
+    pub fn data(&self) -> Option<&T> {
+        unsafe {
+            let raw_data = self.inner.data as *const T;
+
+            if raw_data.is_null() {
+                None
+            } else {
+                Some(&(*raw_data))
+            }
+        }
+    }
+
+    /// Returns a mutable reference to the data associated with this `Peer`, if set.
+    pub fn data_mut(&mut self) -> Option<&mut T> {
+        unsafe {
+            let raw_data = self.inner.data as *mut T;
+
+            if raw_data.is_null() {
+                None
+            } else {
+                Some(&mut (*raw_data))
+            }
+        }
+    }
+
+    /// Sets or clears the data associated with this `Peer`, replacing existing data.
+    pub fn set_data(&mut self, data: Option<T>) {
+        unsafe {
+            let raw_data = self.inner.data as *mut T;
+
+            if !raw_data.is_null() {
+                // free old data
+                let _: Box<T> = Box::from_raw(raw_data);
+            }
+
+            let new_data = match data {
+                Some(data) => Box::into_raw(Box::new(data)) as *mut _,
+                None => std::ptr::null_mut(),
+            };
+
+            self.inner.data = new_data;
+        }
+    }
+
+    /// Returns the downstream bandwidth of this `Peer` in bytes/second.
+    pub fn incoming_bandwidth(&self) -> u32 {
+        self.inner.incomingBandwidth
+    }
+
+    /// Returns the upstream bandwidth of this `Peer` in bytes/second.
+    pub fn outgoing_bandwidth(&self) -> u32 {
+        self.inner.outgoingBandwidth
+    }
+
+    /// Returns the mean round trip time between sending a reliable packet and receiving its acknowledgement.
+    pub fn mean_rtt(&self) -> Duration {
+        Duration::from_millis(self.inner.roundTripTime as u64)
+    }
+
+    /// Forcefully disconnects this `Peer`.
+    ///
+    /// The foreign host represented by the peer is not notified of the disconnection and will timeout on its connection to the local host.
+    pub fn reset(&mut self) {
+        unsafe {
+            enet_peer_reset(&mut self.inner as *mut _);
+        }
+    }
+
+    /// Returns the state this `Peer` is in.
+    pub fn state(&self) -> PeerState {
+        PeerState::from_sys_state(unsafe { self.inner.state })
+    }
+
+    /// Queues a packet to be sent.
+    ///
+    /// Actual sending will happen during `Host::service`.
+    pub fn send_packet(&mut self, packet: Packet, channel_id: u8) -> Result<(), Error> {
+        let res =
+            unsafe { enet_peer_send(&mut self.inner as *mut _, channel_id, packet.into_inner()) };
+
+        match res {
+            r if r > 0 => panic!("unexpected res: {}", r),
+            0 => Ok(()),
+            r if r < 0 => Err(Error(r)),
+            _ => panic!("unreachable"),
+        }
+    }
+
+    /// Disconnects from this peer.
+    ///
+    /// A `Disconnect` event will be returned by `Host::service` once the disconnection is complete.
+    pub fn disconnect(&mut self, user_data: u32) {
+        unsafe {
+            enet_peer_disconnect(&mut self.inner as *mut _, user_data);
+        }
+    }
+
+    /// Disconnects from this peer immediately.
+    ///
+    /// No `Disconnect` event will be created. No disconnect notification for the foreign peer is guaranteed, and this `Peer` is immediately reset on return from this method.
+    pub fn disconnect_now(&mut self, user_data: u32) {
+        unsafe {
+            enet_peer_disconnect_now(&mut self.inner as *mut _, user_data);
+        }
+    }
+
+    /// Disconnects from this peer after all outgoing packets have been sent.
+    ///
+    /// A `Disconnect` event will be returned by `Host::service` once the disconnection is complete.
+    pub fn disconnect_later(&mut self, user_data: u32) {
+        unsafe {
+            enet_peer_disconnect_later(&mut self.inner as *mut _, user_data);
+        }
+    }
 }
 
 /// Describes the state a `Peer` is in.
@@ -76,162 +197,11 @@ impl PeerState {
             _ENetPeerState_ENET_PEER_STATE_CONNECTED => PeerState::Connected,
             _ENetPeerState_ENET_PEER_STATE_DISCONNECT_LATER => PeerState::DisconnectLater,
             _ENetPeerState_ENET_PEER_STATE_DISCONNECTING => PeerState::Disconnecting,
-            _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_DISCONNECT => PeerState::AcknowledgingDisconnect,
+            _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_DISCONNECT => {
+                PeerState::AcknowledgingDisconnect
+            }
             _ENetPeerState_ENET_PEER_STATE_ZOMBIE => PeerState::Zombie,
             val => panic!("unexpected peer state: {}", val),
         }
-    }
-}
-
-impl<'a, T> Peer<'a, T> {
-    pub(crate) fn new(inner: *mut ENetPeer) -> Peer<'a, T> {
-        Peer {
-            inner,
-            _data: PhantomData,
-        }
-    }
-
-    /// Returns the address of this `Peer`.
-    pub fn address(&self) -> Address {
-        Address::from_enet_address(&unsafe { (*self.inner).address })
-    }
-
-    /// Returns the amout of channels allocated for this `Peer`.
-    pub fn channel_count(&self) -> usize {
-        unsafe { (*self.inner).channelCount }
-    }
-
-    /// Returns a reference to the data associated with this `Peer`, if set.
-    pub fn data(&self) -> Option<&T> {
-        unsafe {
-            let raw_data = (*self.inner).data as *const T;
-
-            if raw_data.is_null() {
-                None
-            } else {
-                Some(&(*raw_data))
-            }
-        }
-    }
-
-    /// Returns a mutable reference to the data associated with this `Peer`, if set.
-    pub fn data_mut(&mut self) -> Option<&mut T> {
-        unsafe {
-            let raw_data = (*self.inner).data as *mut T;
-
-            if raw_data.is_null() {
-                None
-            } else {
-                Some(&mut (*raw_data))
-            }
-        }
-    }
-
-    /// Sets or clears the data associated with this `Peer`, replacing existing data.
-    pub fn set_data(&mut self, data: Option<T>) {
-        unsafe {
-            let raw_data = (*self.inner).data as *mut T;
-
-            if !raw_data.is_null() {
-                // free old data
-                let _: Box<T> = Box::from_raw(raw_data);
-            }
-
-            let new_data = match data {
-                Some(data) => Box::into_raw(Box::new(data)) as *mut _,
-                None => std::ptr::null_mut(),
-            };
-
-            (*self.inner).data = new_data;
-        }
-    }
-
-    /// Returns the downstream bandwidth of this `Peer` in bytes/second.
-    pub fn incoming_bandwidth(&self) -> u32 {
-        unsafe { (*self.inner).incomingBandwidth }
-    }
-
-    /// Returns the upstream bandwidth of this `Peer` in bytes/second.
-    pub fn outgoing_bandwidth(&self) -> u32 {
-        unsafe { (*self.inner).outgoingBandwidth }
-    }
-
-    /// Returns the mean round trip time between sending a reliable packet and receiving its acknowledgement.
-    pub fn mean_rtt(&self) -> Duration {
-        Duration::from_millis(unsafe { (*self.inner).roundTripTime } as u64)
-    }
-
-    /// Forcefully disconnects this `Peer`.
-    ///
-    /// The foreign host represented by the peer is not notified of the disconnection and will timeout on its connection to the local host.
-    pub fn reset(self) {
-        unsafe {
-            enet_peer_reset(self.inner);
-        }
-    }
-
-    /// Returns the state this `Peer` is in.
-    pub fn state(&self) -> PeerState {
-        PeerState::from_sys_state(unsafe {(*self.inner).state})
-    }
-
-    /// Queues a packet to be sent.
-    ///
-    /// Actual sending will happen during `Host::service`.
-    pub fn send_packet(&mut self, packet: Packet, channel_id: u8) -> Result<(), Error> {
-        let res = unsafe { enet_peer_send(self.inner, channel_id, packet.into_inner()) };
-
-        match res {
-            r if r > 0 => panic!("unexpected res: {}", r),
-            0 => Ok(()),
-            r if r < 0 => Err(Error(r)),
-            _ => panic!("unreachable"),
-        }
-    }
-
-    /// Disconnects from this peer.
-    ///
-    /// A `Disconnect` event will be returned by `Host::service` once the disconnection is complete.
-    pub fn disconnect(&mut self, user_data: u32) {
-        unsafe {
-            enet_peer_disconnect(self.inner, user_data);
-        }
-    }
-
-    /// Disconnects from this peer immediately.
-    ///
-    /// No `Disconnect` event will be created. No disconnect notification for the foreign peer is guaranteed, and this `Peer` is immediately reset on return from this method.
-    pub fn disconnect_now(self, user_data: u32) {
-        unsafe {
-            enet_peer_disconnect_now(self.inner, user_data);
-        }
-    }
-
-    /// Disconnects from this peer after all outgoing packets have been sent.
-    ///
-    /// A `Disconnect` event will be returned by `Host::service` once the disconnection is complete.
-    pub fn disconnect_later(&mut self, user_data: u32) {
-        unsafe {
-            enet_peer_disconnect_later(self.inner, user_data);
-        }
-    }
-
-    /// Attempts to dequeue an incoming packet from this `Peer`.
-    ///
-    /// On success, returns the packet and the channel id of the receiving channel.
-    pub fn receive<'b>(&'b mut self) -> Option<PeerPacket<'b, 'a, T>> {
-        let mut channel_id = 0u8;
-
-        let res = unsafe { enet_peer_receive(self.inner, &mut channel_id as *mut _) };
-
-        if res.is_null() {
-            return None;
-        }
-
-        Some(PeerPacket {
-            packet: Packet::from_sys_packet(res),
-            channel_id,
-            _priv_guard: PhantomData,
-        })
     }
 }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -2,9 +2,8 @@ use std::marker::PhantomData;
 use std::time::Duration;
 
 use enet_sys::{
-    enet_peer_disconnect, enet_peer_disconnect_later, enet_peer_disconnect_now, enet_peer_receive,
-    enet_peer_reset, enet_peer_send, ENetPeer, _ENetPeerState,
-    _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_CONNECT,
+    enet_peer_disconnect, enet_peer_disconnect_later, enet_peer_disconnect_now, enet_peer_reset,
+    enet_peer_send, ENetPeer, _ENetPeerState, _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_CONNECT,
     _ENetPeerState_ENET_PEER_STATE_ACKNOWLEDGING_DISCONNECT,
     _ENetPeerState_ENET_PEER_STATE_CONNECTED, _ENetPeerState_ENET_PEER_STATE_CONNECTING,
     _ENetPeerState_ENET_PEER_STATE_CONNECTION_PENDING,
@@ -121,7 +120,7 @@ where
 
     /// Returns the state this `Peer` is in.
     pub fn state(&self) -> PeerState {
-        PeerState::from_sys_state(unsafe { self.inner.state })
+        PeerState::from_sys_state(self.inner.state)
     }
 
     /// Queues a packet to be sent.

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -26,17 +26,6 @@ use crate::{Address, Error, Packet};
 ///
 /// ENet allows the association of arbitrary data with each peer.
 /// The type of this associated data is chosen through `T`.
-///
-/// ## Peer lifetimes
-/// An enet `Peer` technically has the same lifetime as the Host it belongs to.
-/// This however also means that a Peer may be ill-defined state, when it does not currently
-/// represent an active connection.
-///
-/// With enet-rs, a specific `PeerID` will only ever reference a `Peer` that corresponds to an
-/// active connection.
-/// As soon as an `Event` that contains an `EventKind::Disconnect` is dropped, the `PeerID` of the
-/// corresponding `Peer` will be invalidated.
-/// The data associated with a Peer will also be dropped at that point.
 #[repr(transparent)]
 pub struct Peer<T> {
     inner: ENetPeer,
@@ -65,6 +54,16 @@ impl<'a, T> Peer<T>
 where
     T: 'a,
 {
+    // -------- Note: Peer lifetimes -------------
+    // An enet `Peer` technically has the same lifetime as the Host it belongs to.
+    // This however also means that a Peer may be in an ill-defined state, when it
+    // does not currently represent an active connection.
+    //
+    // With enet-rs, a specific `PeerID` will only ever reference a `Peer` that corresponds to an
+    // active connection.
+    // As soon as an `Event` that contains an `EventKind::Disconnect` is dropped, the `PeerID` of the
+    // corresponding `Peer` will be invalidated.
+    // The data associated with a Peer will also be dropped at that point.
     pub(crate) fn new(inner: &'a ENetPeer) -> &'a Peer<T> {
         // Safety:
         // This code interprets the `ENetPeer` reference as a `Peer` reference instead.

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -142,29 +142,29 @@ where
     /// Disconnects from this peer.
     ///
     /// A `Disconnect` event will be returned by `Host::service` once the disconnection is complete.
-    pub fn disconnect(&mut self, user_data: u32) {
+    pub fn disconnect(&mut self, data: u32) {
         unsafe {
-            enet_peer_disconnect(&mut self.inner as *mut _, user_data);
+            enet_peer_disconnect(&mut self.inner as *mut _, data);
         }
     }
 
     /// Disconnects from this peer immediately.
     ///
     /// No `Disconnect` event will be created. No disconnect notification for the foreign peer is guaranteed, and this `Peer` is immediately reset on return from this method.
-    pub fn disconnect_now(&mut self, user_data: u32) {
+    pub fn disconnect_now(&mut self, data: u32) {
         self.set_data(None);
 
         unsafe {
-            enet_peer_disconnect_now(&mut self.inner as *mut _, user_data);
+            enet_peer_disconnect_now(&mut self.inner as *mut _, data);
         }
     }
 
     /// Disconnects from this peer after all outgoing packets have been sent.
     ///
     /// A `Disconnect` event will be returned by `Host::service` once the disconnection is complete.
-    pub fn disconnect_later(&mut self, user_data: u32) {
+    pub fn disconnect_later(&mut self, data: u32) {
         unsafe {
-            enet_peer_disconnect_later(&mut self.inner as *mut _, user_data);
+            enet_peer_disconnect_later(&mut self.inner as *mut _, data);
         }
     }
 }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
 use std::time::Duration;
 
@@ -163,6 +164,15 @@ where
         unsafe {
             enet_peer_disconnect_later(&mut self.inner as *mut _, user_data);
         }
+    }
+}
+
+impl<T> Debug for Peer<T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("Peer").field("data", &self.data()).finish()
     }
 }
 

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -152,6 +152,8 @@ where
     ///
     /// No `Disconnect` event will be created. No disconnect notification for the foreign peer is guaranteed, and this `Peer` is immediately reset on return from this method.
     pub fn disconnect_now(&mut self, user_data: u32) {
+        self.set_data(None);
+
         unsafe {
             enet_peer_disconnect_now(&mut self.inner as *mut _, user_data);
         }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -193,7 +193,7 @@ where
     /// Attempts to dequeue an incoming packet from this `Peer`.
     ///
     /// On success, returns the packet and the channel id of the receiving channel.
-    pub fn receive<'b>(&mut self) -> Option<PeerPacket> {
+    pub fn receive(&mut self) -> Option<PeerPacket> {
         let mut channel_id = 0u8;
         let res =
             unsafe { enet_peer_receive(&mut self.inner as *mut _, &mut channel_id as *mut _) };

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -19,6 +19,7 @@ use crate::{Address, Error, Packet};
 ///
 /// The lifetime of these instances is not really clear from the ENet documentation.
 /// Therefore, `Peer`s are always borrowed, and can not really be stored anywhere.
+/// For this purpose, use [PeerID](struct.PeerID.html) instead.
 ///
 /// ENet allows the association of arbitrary data with each peer.
 /// The type of this associated data is chosen through `T`.
@@ -177,6 +178,16 @@ where
         f.debug_struct("Peer").field("data", &self.data()).finish()
     }
 }
+
+/// The ID of a [Peer](struct.Peer.html).
+///
+/// Can be used with the [peer](struct.Host.html#method.peer)/[peer_mut](struct.Host.html#method.peer_mut)-methods of Host, to retrieve references to a Peer.
+/// As the lifetime semantics of Peers aren't clear in Enet and they cannot be owned, PeerID's are the
+/// primary way of storing owned references to Peers.
+///
+/// When connecting to a host, both a reference to the host, and it's ID are returned.
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
+pub struct PeerID(pub(crate) usize);
 
 /// Describes the state a `Peer` is in.
 ///


### PR DESCRIPTION
Implement the changes requested by @futile on #6 .

Additionally, the PeerID is now a separate type, so people can't just pass in arbitrary numbers into the peer indexing.

I chose for now to keep `Index` and `IndexMut` in `Host`. As now the primary way to access a peer is through the host via its `PeerID`, indexing is just a lot more convenient (see `examples/client.rs`).\
If you don't like this, I can of course remove the impl's again.

I decided not to touch the constructors of `Peer`, it does feel quite hacky, but also cleans up the code a fair bit...