### PR TITLE
Fix endianness when creating address from Enet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enet"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Felix Rath <felixm.rath@gmail.com>"]
 edition = "2018"
 description = "High-level, rust-y bindings to the ENet library"


### PR DESCRIPTION
The from_enet_address function actually returned the wrong byte order on little endian machines (like x86).

This is now fixed, Ipv4Addr and Enet already use the same network byte order (big endian). So just never change it when converting.